### PR TITLE
Please add support for configuring the XJC Ant task backing the plugin. 

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -95,6 +95,7 @@ If this value is false '-nv' will be added to the command line parameter list.
 |*bindings*           | `FileCollection` | `null`    | To specify more than one external binding file at the same time, use this configuration.
 |*targetVersion*      | `String`    | `'2.2'`       | Specifies the runtime environment in which the generated code is supposed to run. Expects also 2.0 or 2.1 values. This allows more up-to-date versions of XJC to be used for developing applications that run on earlier JAXB versions.
 |*language*           | `String`    | `'XMLSCHEMA'` | Specifies the schema language to compile. Supported values are "WSDL", "XMLSCHEMA", and "WSDL." Case insensitive.
+|*antTaskClassName*   | `String`    | `'com.sun.tools.xjc.XJCTask'` | The JAXB tools (e.g. XJC) bundled with the JDK are relocated to a package not matching the JAXB-RI. There are a lot of XJC plugins around compiled against the JAXB-RI which cannot be used with the JAXB tools bundled with the JDK due to this. When configuring the plugin to use the JAXB-RI Ant task instead of the Ant task bundled with the JDK (e.g. com.sun.tools.xjc.XJC2Task), those plugins can be used.
 |===
 
 ===== Method

--- a/src/main/groovy/com/intershop/gradle/jaxb/JaxbPlugin.groovy
+++ b/src/main/groovy/com/intershop/gradle/jaxb/JaxbPlugin.groovy
@@ -92,6 +92,7 @@ class JaxbPlugin implements Plugin<Project> {
             task.conventionMapping.extension = { javaGen.getExtension() }
             task.conventionMapping.language = { javaGen.getLanguage() }
             task.conventionMapping.parameters = { javaGen.getArgs() }
+            task.conventionMapping.antTaskClassName = { javaGen.getAntTaskClassName() }
 
             // identify sourceset configuration and add output to sourceset
             project.afterEvaluate {

--- a/src/main/groovy/com/intershop/gradle/jaxb/extension/JaxbExtension.groovy
+++ b/src/main/groovy/com/intershop/gradle/jaxb/extension/JaxbExtension.groovy
@@ -58,6 +58,11 @@ class JaxbExtension {
     final static String DEFAULT_SOURCESET_NAME = 'main'
 
     /**
+     * Default Ant task class name.
+     */
+    final static String DEFAULT_ANT_TASK_CLASS_NAME = 'com.sun.tools.xjc.XJCTask'
+
+    /**
      * Container for schema generation configurations
      */
     final NamedDomainObjectContainer<JavaToSchema> schemaGen

--- a/src/main/groovy/com/intershop/gradle/jaxb/extension/SchemaToJava.groovy
+++ b/src/main/groovy/com/intershop/gradle/jaxb/extension/SchemaToJava.groovy
@@ -149,6 +149,19 @@ class SchemaToJava implements Named {
     }
 
     /**
+     * The class name of the Ant task backing the Gradle task.
+     */
+    String antTaskClassName;
+
+    String getAntTaskClassName() {
+        if(! this.antTaskClassName) {
+            return JaxbExtension.DEFAULT_ANT_TASK_CLASS_NAME;
+        } else {
+            return this.antTaskClassName;
+        }
+    }
+
+    /**
      * Calculates the task name
      *
      * @return task name with prefix jaxbJavaGen

--- a/src/main/groovy/com/intershop/gradle/jaxb/task/SchemaToJavaTask.groovy
+++ b/src/main/groovy/com/intershop/gradle/jaxb/task/SchemaToJavaTask.groovy
@@ -82,13 +82,16 @@ class SchemaToJavaTask extends DefaultTask {
     @Input
     List<String> parameters
 
+    @Input
+    String antTaskClassName
+
     @TaskAction
     void generate() {
         FileCollection jaxbConfiguration = getProject().getConfigurations().getAt(JaxbExtension.JAXB_CONFIGURATION_NAME)
         FileCollection xjcConfiguration = getProject().getConfigurations().maybeCreate('xjc')
 
         ant.taskdef (name : 'xjc',
-                classname : 'com.sun.tools.xjc.XJCTask',
+                classname : getAntTaskClassName(),
                 classpath : jaxbConfiguration.asPath)
 
         def args = [destdir	        : getOutputDirectory(),


### PR DESCRIPTION
The JAXB tools (e.g. XJC) bundled with the JDK are relocated to a package not
matching the JAXB-RI. There are a lot of XJC plugins around compiled against
the JAXB-RI which cannot be used with the JAXB tools bundled with the JDK due
to this. When configuring the plugin to use the JAXB-RI Ant task instead of the
Ant task bundled with the JDK (e.g. com.sun.tools.xjc.XJC2Task), those plugins
can be used.